### PR TITLE
Adds support for GNOME 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "gettext-domain": "otp-keys",
   "settings-schema": "org.gnome.shell.extensions.otp-keys",
   "shell-version": [
-    "45", "46"
+    "45", "46", "47"
   ],
-  "version": 23
+  "version": 24
 }


### PR DESCRIPTION
I know this change is pretty basic, but I just upgraded to GNOME 47 and the extension seems to work smoothly without needing any further changes.